### PR TITLE
Fix issue where package is built using march=native

### DIFF
--- a/higan.spec
+++ b/higan.spec
@@ -31,6 +31,15 @@ sed -i \
         -e "/handle/s#/usr/local/lib#/usr/%{_libdir}#" \
         nall/dl.hpp || die "fixing libdir failed!"
 
+# fix so that it doesn't build march=native
+pushd higan
+sed -i 's/march=native/march=x86-64/g' GNUmakefile
+popd
+
+pushd icarus
+sed -i 's/march=native/march=x86-64/g' GNUmakefile
+popd
+
 
 %build
 pushd icarus


### PR DESCRIPTION
Hello,

It seems higan changed the Makefile lately such that it builds with march=native. That means that if someone builds using this specfile, the rpm will mostly likely only work on their machine, rather than on all x86-64 machines.

Anyway I hacked it to search/replace the march=native with march=x86-64 which fixes the issue.

Thanks!
